### PR TITLE
feat:create first agent

### DIFF
--- a/multi_tool_agent/__init__.py
+++ b/multi_tool_agent/__init__.py
@@ -1,0 +1,1 @@
+from . import agent

--- a/multi_tool_agent/agent.py
+++ b/multi_tool_agent/agent.py
@@ -1,0 +1,67 @@
+import datetime
+from zoneinfo import ZoneInfo
+from google.adk.agents import Agent
+
+def get_weather(city: str) -> dict:
+    """Retrieves the current weather report for a specified city.
+
+    Args:
+        city (str): The name of the city for which to retrieve the weather report.
+
+    Returns:
+        dict: status and result or error msg.
+    """
+    if city.lower() == "new york":
+        return {
+            "status": "success",
+            "report": (
+                "The weather in New York is sunny with a temperature of 25 degrees"
+                " Celsius (77 degrees Fahrenheit)."
+            ),
+        }
+    else:
+        return {
+            "status": "error",
+            "error_message": f"Weather information for '{city}' is not available.",
+        }
+
+
+def get_current_time(city: str) -> dict:
+    """Returns the current time in a specified city.
+
+    Args:
+        city (str): The name of the city for which to retrieve the current time.
+
+    Returns:
+        dict: status and result or error msg.
+    """
+
+    if city.lower() == "new york":
+        tz_identifier = "America/New_York"
+    else:
+        return {
+            "status": "error",
+            "error_message": (
+                f"Sorry, I don't have timezone information for {city}."
+            ),
+        }
+
+    tz = ZoneInfo(tz_identifier)
+    now = datetime.datetime.now(tz)
+    report = (
+        f'The current time in {city} is {now.strftime("%Y-%m-%d %H:%M:%S %Z%z")}'
+    )
+    return {"status": "success", "report": report}
+
+
+root_agent = Agent(
+    name="weather_time_agent",
+    model="gemini-2.0-flash",
+    description=(
+        "Agent to answer questions about the time and weather in a city."
+    ),
+    instruction=(
+        "You are a helpful agent who can answer user questions about the time and weather in a city."
+    ),
+    tools=[get_weather, get_current_time],
+)


### PR DESCRIPTION
This pull request introduces a new agent for answering questions about the time and weather in a city, along with utility functions to support these features. The main changes are the addition of the agent setup and the weather/time retrieval functions, as well as an import update to expose the agent module.

Agent and utilities for weather and time:

* Added the `get_weather` function to provide weather reports for New York, with error handling for unsupported cities.
* Added the `get_current_time` function to provide the current time for New York, including timezone handling, with error handling for unsupported cities.
* Defined a new `root_agent` using the `Agent` class, configured with a description, instructions, and the new weather/time tools.

Module structure:

* Updated `multi_tool_agent/__init__.py` to import the new `agent` module, making the agent accessible from the package root.